### PR TITLE
Added uid2sid

### DIFF
--- a/appbase/users/sessions.py
+++ b/appbase/users/sessions.py
@@ -27,6 +27,10 @@ def get_for(uid):
     return get(sid)
 
 
+def uid2sid(uid):
+    return rconn.hget(rev_lookup_key, uid)
+
+
 def sid2uidgroups(sid):
     """
     => uid (int), groups (list)


### PR DESCRIPTION
Added `uid2sid`, a utility method to get a user's session id from `uid`.